### PR TITLE
Make mysql_fd return -1 if no active DB connection

### DIFF
--- a/lib/DBD/mysql.pm
+++ b/lib/DBD/mysql.pm
@@ -1885,12 +1885,15 @@ or in the L<DBI/prepare> method.  Statements created with 'async' set to
 true in prepare always run their queries asynchronously when L<DBI/execute>
 is called.  The driver also offers three additional methods:
 C<mysql_async_result>, C<mysql_async_ready>, and C<mysql_fd>.
+
 C<mysql_async_result> returns what do or execute would have; that is, the
 number of rows affected.  C<mysql_async_ready> returns true if
 C<mysql_async_result> will not block, and zero otherwise.  They both return
 C<undef> if that handle is not currently running an asynchronous query.
+
 C<mysql_fd> returns the file descriptor number for the MySQL connection; you
-can use this in an event loop.
+can use this in an event loop.  It returns -1 if there is no active database
+connection.
 
 Here's an example of how to use the asynchronous query interface:
 

--- a/mysql.xs
+++ b/mysql.xs
@@ -624,7 +624,7 @@ int mysql_fd(dbh)
   CODE:
     {
         D_imp_dbh(dbh);
-        RETVAL = imp_dbh->pmysql->net.fd;
+        RETVAL = imp_dbh->pmysql->net.vio ? imp_dbh->pmysql->net.fd : -1;
     }
   OUTPUT:
     RETVAL

--- a/t/87async.t
+++ b/t/87async.t
@@ -240,3 +240,6 @@ $sth->finish;
 
 undef $sth;
 ok $dbh->disconnect;
+
+is $dbh->mysql_fd, -1;
+


### PR DESCRIPTION
This avoids returning state file handle info if the DB is disconnected.

It fixes https://rt.cpan.org/Public/Bug/Display.html?id=110983